### PR TITLE
Fix/cuda warning options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,7 +435,7 @@ set(cuda_flags ${cxx_flags} -use_fast_math ${cuda_flags})
 
 list(JOIN host_cxx_flags " " cuda_host_flags)  # pass host compiler flags as a single argument
 if (NOT cuda_host_flags STREQUAL "")
-    set(cuda_flags ${cuda_flags} -Xcompiler ${cuda_host_flags})
+    set(cuda_flags -forward-unknown-to-host-compiler ${cuda_flags} -Xcompiler ${cuda_host_flags})
 endif()
 
 add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:${cuda_flags}>")

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Please kindly refer to our [Project Kanban](https://github.com/orgs/KAIST-KEAI/p
 
 Optiml requires the following dependencies:
 
-- CMake (3.13+)
+- CMake (3.17+)
 - Python (3.8+) and pip (19.3+), for converting model weights and automatic FFN offloading
 
 ### Get the Code
@@ -101,7 +101,7 @@ pip install -r requirements.txt # install Python helpers' dependencies
 ### Build
 In order to build Optiml you have two different options. These commands are supposed to be run from the root directory of the project.
 
-Using `CMake`(3.13+):
+Using `CMake`(3.17+):
 * If you have an NVIDIA GPU:
 ```bash
 cmake -S . -B build -DLLAMA_CUBLAS=ON

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -7,11 +7,11 @@
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../.git")
     set(GIT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.git")
 
-    # Is git submodule
+    # Is git submodule/worktree
     if(NOT IS_DIRECTORY "${GIT_DIR}")
         file(READ ${GIT_DIR} REAL_GIT_DIR_LINK)
         string(REGEX REPLACE "gitdir: (.*)\n$" "\\1" REAL_GIT_DIR ${REAL_GIT_DIR_LINK})
-        set(GIT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../${REAL_GIT_DIR}")
+        set(GIT_DIR "${REAL_GIT_DIR}")
     endif()
 
     set(GIT_INDEX "${GIT_DIR}/index")

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -73,6 +73,9 @@
 #define cudaStreamWaitEvent(stream, event, flags) hipStreamWaitEvent(stream, event, flags)
 #define cudaStream_t hipStream_t
 #define cudaSuccess hipSuccess
+// fix cuda function not defined for rocm
+#define cudaMemGetInfo hipMemGetInfo
+#define cudaMemcpyToSymbol hipMemcpyToSymbol
 #else
 #include <cuda_runtime.h>
 #include <cublas_v2.h>


### PR DESCRIPTION
In ./ggml-cuda.cu, there were missing definitions for cudaMemGetInfo and cudaMemcpyToSymbol, preventing the code being compiled. Add two macro definitions fixes the problem.

Tested with ROCm 5.6/AMD Clang 16.0 on Ryzen 7840HS/Radeon GFX1103 (need to manually override compute capability by export HSA_OVERRIDE_GFX_VERSION=11.0.1). Code compiles and runs. Performance and correctness could not be tested at this moment.